### PR TITLE
📥 Specify that `CardComponent` and `AtomComponent` receive payload prop

### DIFF
--- a/SectionRenderer/CardSectionRenderer/CardRenderer/index.ts
+++ b/SectionRenderer/CardSectionRenderer/CardRenderer/index.ts
@@ -1,10 +1,10 @@
-import { CreateElement, ElementTypeGetter, Node } from '../../../types'
+import { CreateElement, CardComponentGetter, Node } from '../../../types'
 import { Card } from '../../../types/Mobiledoc'
 import { throwError } from '../../../utils'
 
 export interface Options {
   createElement: CreateElement
-  getCardComponent: ElementTypeGetter
+  getCardComponent: CardComponentGetter
 }
 
 export default ({ createElement, getCardComponent }: Options) => ([

--- a/SectionRenderer/CardSectionRenderer/index.ts
+++ b/SectionRenderer/CardSectionRenderer/index.ts
@@ -1,10 +1,10 @@
-import { CreateElement, ElementTypeGetter, Node } from '../../types'
+import { CreateElement, CardComponentGetter, Node } from '../../types'
 import { Card, CardSection } from '../../types/Mobiledoc'
 import CardRenderer from './CardRenderer'
 
 export interface Options {
   createElement: CreateElement
-  getCardComponent: ElementTypeGetter
+  getCardComponent: CardComponentGetter
 }
 
 export interface Context {

--- a/SectionRenderer/ListSectionRenderer/index.ts
+++ b/SectionRenderer/ListSectionRenderer/index.ts
@@ -1,4 +1,9 @@
-import { CreateElement, ElementTypeGetter, Node } from '../../types'
+import {
+  CreateElement,
+  AtomComponentGetter,
+  ElementTypeGetter,
+  Node
+} from '../../types'
 import {
   ListItemTagName,
   ListSection,
@@ -13,7 +18,7 @@ const ITEM_TAG_NAME = ListItemTagName.li
 export interface Options {
   createElement: CreateElement
   getElement: ElementTypeGetter
-  getAtomComponent: ElementTypeGetter
+  getAtomComponent: AtomComponentGetter
 }
 
 export interface Context {

--- a/SectionRenderer/MarkersRenderer/MarkerContentRenderer/AtomRenderer/index.ts
+++ b/SectionRenderer/MarkersRenderer/MarkerContentRenderer/AtomRenderer/index.ts
@@ -1,10 +1,10 @@
-import { CreateElement, ElementTypeGetter, Node } from '../../../../types'
+import { CreateElement, AtomComponentGetter, Node } from '../../../../types'
 import { Atom } from '../../../../types/Mobiledoc'
 import { throwError } from '../../../../utils'
 
 export interface Options {
   createElement: CreateElement
-  getAtomComponent: ElementTypeGetter
+  getAtomComponent: AtomComponentGetter
 }
 
 export default ({ createElement, getAtomComponent }: Options) => ([

--- a/SectionRenderer/MarkersRenderer/MarkerContentRenderer/index.ts
+++ b/SectionRenderer/MarkersRenderer/MarkerContentRenderer/index.ts
@@ -1,10 +1,10 @@
-import { CreateElement, ElementTypeGetter, Node } from '../../../types'
+import { CreateElement, AtomComponentGetter, Node } from '../../../types'
 import { Atom, Marker, MarkerTypeIdentifier } from '../../../types/Mobiledoc'
 import AtomRenderer from './AtomRenderer'
 
 export interface Options {
   createElement: CreateElement
-  getAtomComponent: ElementTypeGetter
+  getAtomComponent: AtomComponentGetter
 }
 
 export interface Context {

--- a/SectionRenderer/MarkersRenderer/index.ts
+++ b/SectionRenderer/MarkersRenderer/index.ts
@@ -1,4 +1,9 @@
-import { CreateElement, ElementTypeGetter, Node } from '../../types'
+import {
+  CreateElement,
+  AtomComponentGetter,
+  ElementTypeGetter,
+  Node
+} from '../../types'
 import { Marker, Atom, Markup } from '../../types/Mobiledoc'
 import { pipe } from '../../utils'
 import MarkupRenderer, {
@@ -64,7 +69,7 @@ const MarkerMarkupNodesCloser = ({
 
 export interface Options {
   createElement: CreateElement
-  getAtomComponent: ElementTypeGetter
+  getAtomComponent: AtomComponentGetter
   getElement: ElementTypeGetter
 }
 

--- a/SectionRenderer/MarkupSectionRenderer/index.ts
+++ b/SectionRenderer/MarkupSectionRenderer/index.ts
@@ -1,11 +1,16 @@
-import { CreateElement, ElementTypeGetter, Node } from '../../types'
+import {
+  CreateElement,
+  AtomComponentGetter,
+  ElementTypeGetter,
+  Node
+} from '../../types'
 import { Markup, Atom, MarkupSection } from '../../types/Mobiledoc'
 import { throwError } from '../../utils'
 import MarkersRenderer from '../MarkersRenderer'
 
 export interface Options {
   createElement: CreateElement
-  getAtomComponent: ElementTypeGetter
+  getAtomComponent: AtomComponentGetter
   getElement: ElementTypeGetter
 }
 

--- a/SectionRenderer/index.ts
+++ b/SectionRenderer/index.ts
@@ -1,4 +1,10 @@
-import { CreateElement, ElementTypeGetter, Node } from '../types'
+import {
+  CreateElement,
+  CardComponentGetter,
+  AtomComponentGetter,
+  ElementTypeGetter,
+  Node
+} from '../types'
 import {
   Markup,
   Card,
@@ -13,8 +19,8 @@ import CardSectionRenderer from './CardSectionRenderer'
 
 export interface Options {
   createElement: CreateElement
-  getCardComponent: ElementTypeGetter
-  getAtomComponent: ElementTypeGetter
+  getCardComponent: CardComponentGetter
+  getAtomComponent: AtomComponentGetter
   getElement: ElementTypeGetter
 }
 

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,11 @@
-import { Mobiledoc, CreateElement, ElementTypeGetter, Node } from './types'
+import {
+  Mobiledoc,
+  CreateElement,
+  CardComponentGetter,
+  AtomComponentGetter,
+  ElementTypeGetter,
+  Node
+} from './types'
 import SectionRenderer from './SectionRenderer'
 import upgradeMobiledoc from './upgradeMobiledoc'
 import getElementDefault from './getElementDefault'
@@ -15,8 +22,8 @@ export const canParse = semverMatchesMinor(SUPPORTED_MOBILEDOC_VERSION)
 
 export interface Options {
   createElement: CreateElement
-  getCardComponent: ElementTypeGetter
-  getAtomComponent: ElementTypeGetter
+  getCardComponent: CardComponentGetter
+  getAtomComponent: AtomComponentGetter
   getElement: ElementTypeGetter
 }
 

--- a/package.json
+++ b/package.json
@@ -192,7 +192,8 @@
         ],
         "rules": {
           "no-unused-vars": "off",
-          "no-undef": "off"
+          "no-undef": "off",
+          "space-infix-ops": "off"
         }
       },
       {

--- a/types/index.ts
+++ b/types/index.ts
@@ -1,6 +1,16 @@
-import { ElementType } from './CreateElement'
+import { ElementType, Node } from './CreateElement'
 
 export { default as Mobiledoc } from './Mobiledoc'
 export { default as CreateElement, Node } from './CreateElement'
 
-export type ElementTypeGetter = (type: string) => ElementType
+export type CardComponent = (properties: object) => Node
+
+export type AtomComponent = (properties: object) => Node
+
+export type Getter<type> = (type: string) => type
+
+export type CardComponentGetter = Getter<CardComponent>
+
+export type AtomComponentGetter = Getter<AtomComponent>
+
+export type ElementTypeGetter = Getter<ElementType>

--- a/types/index.ts
+++ b/types/index.ts
@@ -3,9 +3,13 @@ import { ElementType, Node } from './CreateElement'
 export { default as Mobiledoc } from './Mobiledoc'
 export { default as CreateElement, Node } from './CreateElement'
 
-export type CardComponent = (properties: object) => Node
+export type CardComponent = (
+  properties: { payload: object; [key: string]: any }
+) => Node
 
-export type AtomComponent = (properties: object) => Node
+export type AtomComponent = (
+  properties: { payload: object; [key: string]: any }
+) => Node
 
 export type Getter<type> = (type: string) => type
 


### PR DESCRIPTION
#10 

Failing as of 54fa197 because I can’t pass `CardComponent` (`(properties: { payload: object; [key: string]: any }) => Node`) to `createElement` as a `Component` (`(properties: object) => Node`).

Any thoughts?