### PR TITLE
🙃 "module" build should transpile to es5 but keep import/exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,9 @@
     "start": "concurrently 'npm run watch:lint' 'npm run watch:test' --raw",
     "commitmsg": "commit-msg-must-use-emoji",
     "build": "tsc --project tsconfig.module.json && tsc",
+    "clean": "rm -rf dist",
     "prepublishOnly": "npm test && rm -rf dist && npm run build",
-    "postpublish": "rm -rf dist"
+    "postpublish": "npm run clean"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,7 @@
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "lib": ["ES5"]
+    "noUnusedParameters": true
   },
   "exclude": ["node_modules", "dist"]
 }

--- a/tsconfig.module.json
+++ b/tsconfig.module.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
-    "module": "ES2015",
+    "target": "ES5",
     "outDir": "dist/module",
     "declaration": true,
     "moduleResolution": "Node"


### PR DESCRIPTION
Allows webpack, etc. to import/export and treeshake without having to transpile the syntax to es5.

Closes #16
